### PR TITLE
Ajax cross-domain checks enforcement

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -545,8 +545,8 @@ TraceKit.computeStackTrace = (function () {
 			return null;
 		}
 
-		var chrome = /^\s*at (\S+) \(((?:file|http):.*?):(\d+)(?::(\d+))?\)\s*$/i,
-			gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|http).*?):(\d+)(?::(\d+))?\s*$/i,
+		var chrome = /^\s*at (\S+) \(((?:file|http|https):.*?):(\d+)(?::(\d+))?\)\s*$/i,
+			gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|http|https).*?):(\d+)(?::(\d+))?\s*$/i,
 			lines = ex.stack.split("\n"),
 			stack = [],
 			parts,
@@ -671,8 +671,8 @@ TraceKit.computeStackTrace = (function () {
 			return null;
 		}
 
-		var lineRE1 = /^\s*Line (\d+) of linked script ((?:file|http)\S+)(?:: in function (\S+))?\s*$/i,
-			lineRE2 = /^\s*Line (\d+) of inline#(\d+) script in ((?:file|http)\S+)(?:: in function (\S+))?\s*$/i,
+		var lineRE1 = /^\s*Line (\d+) of linked script ((?:file|http|https)\S+)(?:: in function (\S+))?\s*$/i,
+			lineRE2 = /^\s*Line (\d+) of inline#(\d+) script in ((?:file|http|https)\S+)(?:: in function (\S+))?\s*$/i,
 			lineRE3 = /^\s*Line (\d+) of function script\s*$/i,
 			stack = [],
 			scripts = document.getElementsByTagName('script'),


### PR DESCRIPTION
If you include Google JS API's, then cross-domain errors get flagged when trying to do Ajax calls to retrieve them.
