### PR TITLE
Handle exceptions on windows phone 8 in cordova.

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -367,8 +367,9 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             // cross-domain errors will be triggered.
             var source = '';
 
-            url = url || '';
-            if (url.indexOf && url.indexOf(document.domain) !== -1) {
+            var domain = '';
+            try { domain = document.domain; } catch (e) {}
+            if (url.indexOf(domain) !== -1) {
                 source = loadSource(url);
             }
             sourceCache[url] = source ? source.split('\n') : [];


### PR DESCRIPTION
This is because you cannot access `document.domain` on windows phone 8. 

I also removed the check for `.indexOf`. This change introduced it: https://github.com/csnover/TraceKit/blob/53e554774c02c7f76bfef33237525060459a5f6c/tracekit.js#L364 it probably wasn't necessary because if `url` was `undefined` it was assigned to be an empty string. The current version of this function explicitly checks if `url` is a string.

    String.prototype.indexOf

Is supported in every browser since the dawn of man (JavaScript 1.0), so we don't need need to check the general case.
