### PR TITLE
Update regex and tests for indexed functions

### DIFF
--- a/spec/fixtures/captured-errors.js
+++ b/spec/fixtures/captured-errors.js
@@ -170,7 +170,8 @@ CapturedExceptions.CHROME_36 = {
     name: "Error",
     stack: "Error: Default error\n" +
     "    at dumpExceptionError (http://localhost:8080/file.js:41:27)\n" +
-    "    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)"
+    "    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)\n" +
+    "    at I.e.fn.(anonymous function) [as index] (http://localhost:8080/file.js:10:3651)"
 };
 
 CapturedExceptions.FIREFOX_3 = {
@@ -216,6 +217,7 @@ CapturedExceptions.FIREFOX_31 = {
     name: "Error",
     stack: "foo@http://path/to/file.js:41:13\n" +
     "bar@http://path/to/file.js:1:1\n" +
+    ".plugin/e.fn[c]/<@http://path/to/file.js:1:1\n" +
     "",
     fileName: "http://path/to/file.js",
     lineNumber: 41,

--- a/spec/tracekit-parser-spec.js
+++ b/spec/tracekit-parser-spec.js
@@ -98,9 +98,10 @@
         it('should parse Firefox 31 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_31);
             expect(stackFrames).toBeTruthy();
-            expect(stackFrames.stack.length).toBe(2);
+            expect(stackFrames.stack.length).toBe(3);
             expect(stackFrames.stack[0]).toEqual({ url: 'http://path/to/file.js', func: 'foo', args: [], line: 41, column: 13, context: null });
             expect(stackFrames.stack[1]).toEqual({ url: 'http://path/to/file.js', func: 'bar', args: [], line: 1, column: 1, context: null });
+            expect(stackFrames.stack[2]).toEqual({ url: 'http://path/to/file.js', func: '.plugin/e.fn[c]/<', args: [], line: 1, column: 1, context: null });
         });
 
         it('should parse Chrome error with no location', function () {
@@ -122,9 +123,10 @@
         it('should parse Chrome 36 error with port numbers', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_36);
             expect(stackFrames).toBeTruthy();
-            expect(stackFrames.stack.length).toBe(2);
+            expect(stackFrames.stack.length).toBe(3);
             expect(stackFrames.stack[0]).toEqual({ url: 'http://localhost:8080/file.js', func: 'dumpExceptionError', args: [], line: 41, column: 27, context: null });
             expect(stackFrames.stack[1]).toEqual({ url: 'http://localhost:8080/file.js', func: 'HTMLButtonElement.onclick', args: [], line: 107, column: 146, context: null });
+            expect(stackFrames.stack[2]).toEqual({ url: 'http://localhost:8080/file.js', func: 'I.e.fn.(anonymous function) [as index]', args: [], line: 10, column: 3651, context: null });
         });
 
         it('should parse Chrome error with blob URLs', function () {

--- a/tracekit.js
+++ b/tracekit.js
@@ -638,7 +638,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         }
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(.*?)(?:\((.*?)\))?@?((?:file|https?|blob|chrome|\[).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|\[).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],


### PR DESCRIPTION
```
Firefox: .plugin/e.fn[c]/<@http://path/to/file.js:1:1
Chrome:     at I.e.fn.(anonymous function) [as index] (http://localhost:8080/file.js:10:3651)
```

For Chrome, the regex is fine, simply added the text to the tests.
For Firefox, the indexer [c] was being detected as part of the URL because of the regex testing for \[native code\] in the URL (```|\[).*?```).

https://regex101.com/r/hA0mR3/1