### PR TITLE
Improve the CORS matching logic in getSource

### DIFF
--- a/spec/tracekit-computestacktrace-spec.js
+++ b/spec/tracekit-computestacktrace-spec.js
@@ -1,0 +1,24 @@
+(function() {
+    'use strict';
+
+    describe('computeStackTrace', function(){
+        describe('domain regex', function(){
+            var regex = /(.*)\:\/\/([^\/]+)\/{0,1}([\s\S]*)/;
+            it('should return subdomains properly', function (){
+                var url = 'https://subdomain.yoursite.com/assets/main.js';
+                var domain = 'subdomain.yoursite.com';
+                expect(regex.exec(url)[2]).toBe(domain);
+            });
+            it('should return domains correctly with any protocol', function(){
+                var url = 'http://yoursite.com/assets/main.js';
+                var domain = 'yoursite.com';
+                expect(regex.exec(url)[2]).toBe(domain);
+            });
+            it('should return the correct domain when directories match the domain', function(){
+                var url = 'https://mysite.com/mysite/main.js';
+                var domain = 'mysite.com';
+                expect(regex.exec(url)[2]).toBe(domain);
+            });
+        });
+    });
+})();

--- a/tracekit.js
+++ b/tracekit.js
@@ -364,7 +364,8 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             var source = '';
             var domain = '';
             try { domain = document.domain; } catch (e) {}
-            if (url.indexOf(domain) !== -1) {
+            var match = /(.*)\:\/\/([^\/]+)\/{0,1}([\s\S]*)/.exec(url);
+            if (match && match[2] === domain) {
                 source = loadSource(url);
             }
             sourceCache[url] = source ? source.split('\n') : [];


### PR DESCRIPTION
Before this, domains which contained the original domain (staticsub.domain.com -> sub.domain.com) would match.

I attempted to create some tests around getSource, but was unsuccessful. Here was my attempt:
```
(function() {
    'use strict';

    describe('ComputeStackTrace', function(){
        describe('getSource', function() {
            it('it should return the source of a file from a matching domain', function () {
                var xhrObj = jasmine.createSpyObj('xhrObj',
                    ['addEventListener', 'open', 'send']);
                spyOn(window, "XMLHttpRequest").andReturn(xhrObj);
                var source = TraceKit.computeStackTrace.getSource('https://testdomain.com/public/file.js');
                expect(source).toBe('file value1');
            });
        });
    });
})();
```

Returns "TypeError: '[object XMLHttpRequestConstructor]' is not a function (evaluating 'window.XMLHttpRequest()') in file:///Users/jsteele1/Documents/dev/TraceKit/spec/tracekit-computeStackTrace-spec.js (line 10) (1)"