### PR TITLE
Add a missing parameter to notifyHandlers' JSDoc

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -145,6 +145,7 @@ TraceKit.report = (function reportModuleWrapper() {
     /**
      * Dispatch stack information to all handlers.
      * @param {Object.<string, *>} stack
+     * @param {boolean} isWindowError Is this a top-level window error?
      * @memberof TraceKit.report
      */
     function notifyHandlers(stack, isWindowError) {


### PR DESCRIPTION
We were missing a parameter in one of the function's JSDoc.