### PR TITLE
Added module export to typings

### DIFF
--- a/tracekit.d.ts
+++ b/tracekit.d.ts
@@ -232,3 +232,5 @@ declare module TraceKit {
   var collectWindowErrors:boolean;
   var linesOfContext:boolean;
 }
+
+export = TraceKit


### PR DESCRIPTION
The `export = TraceKit` assignment is needed for the module to be used as regular import:

`import * as TraceKit from 'tracekit'`