### PR TITLE
Update grunt-jsdoc to version 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-cli": "1.2.0",
     "grunt-contrib-jasmine": "1.0.3",
     "grunt-contrib-jshint": "1.0.0",
-    "grunt-jsdoc": "2.0.0",
+    "grunt-jsdoc": "2.1.0",
     "jasmine": "2.4.1",
     "jasmine-core": "2.4.1",
     "karma": "0.13.22",


### PR DESCRIPTION
Not much new from the version (see https://github.com/krampstudio/grunt-jsdoc/releases/tag/2.1.0), just keeping up to date.

> 
* use cross-spawn instead of cross-spawn-async,
* add generating and generated grunt events

Output is identical between the two dependency versions.