### PR TITLE
TraceKit can now be used on frames

### DIFF
--- a/tracekit.js
+++ b/tracekit.js
@@ -128,11 +128,11 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {Function} handler
      * @memberof TraceKit.report
      */
-    function subscribe(handler, aWindow) {
-      aWindow = (aWindow || window);
-      if (isWindowAccessible(aWindow)) {
-        TraceKit.windowPointer = aWindow;
-        installGlobalHandler(handler, aWindow);
+    function subscribe(handler, win) {
+      win = (win || window);
+      if (isWindowAccessible(win)) {
+        TraceKit.windowPointer = win;
+        installGlobalHandler(handler, win);
       }
     }
 
@@ -141,11 +141,11 @@ TraceKit.report = (function reportModuleWrapper() {
      * @param {Function} handler
      * @memberof TraceKit.report
      */
-    function unsubscribe(handler, aWindow) {
-      aWindow = (aWindow || window);
-      if (isWindowAccessible(aWindow)) {
+    function unsubscribe(handler, win) {
+      win = (win || window);
+      if (isWindowAccessible(win)) {
         for (var i = handlers.length - 1; i >= 0; --i) {
-          if (handlers[i][0] === handler && aWindow === handlers[i][1]) {
+          if (handlers[i][0] === handler && win === handlers[i][1]) {
                 handlers.splice(i, 1);
             }
         }

--- a/tracekit.js
+++ b/tracekit.js
@@ -233,10 +233,10 @@ TraceKit.report = (function reportModuleWrapper() {
       if (aWindow._onErrorHandlerInstalled === true) {
             return;
         }
-      var _oldOnerrorHandler = aWindow.onerror;
+      var oldOnerrorHandler = aWindow.onerror;
       aWindow.onerror = traceKitWindowOnError;
       aWindow._onErrorHandlerInstalled = true;
-      handlers.push([aHandlers, aWindow, _oldOnerrorHandler]);
+      handlers.push([aHandlers, aWindow, oldOnerrorHandler]);
     }
 
     /**


### PR DESCRIPTION
Hi, have made this change so, I only need to include TraceKit once on my frame page. 

Here is the code for the frame page.

    function insertTraceKit() {

      function yourLogger(errorReport) {
        console.log(errorReport);
        return true;
      }

      TraceKit.report.subscribe(yourLogger);

      function wrapped(aThis) {
        TraceKit.report.subscribe(yourLogger, aThis.target.contentWindow);
        try {
          aThis.target.contentWindow.onunload = unwrapped;
        } catch (e) {
          //console.log('cross-origin frame detected');
        }
      }

      function unwrapped(aThis) {
        TraceKit.report.unsubscribe(yourLogger, aThis.currentTarget);
      }

      var frames = document.getElementsByTagName('frame');
      for (var i = 0; i < frames.length; i++) {
        frames[i].onload = wrapped;
      };

    }

    var readyStateCheckInterval = setInterval(waitInit, 10, this);

    function waitInit() {
      //console.log(document.readyState);
      if (document.readyState === "interactive") {
        clearInterval(readyStateCheckInterval);
        insertTraceKit();
      }
    }