### PR TITLE
fix(type): nullable context

### DIFF
--- a/tracekit.d.ts
+++ b/tracekit.d.ts
@@ -4,7 +4,7 @@ export interface StackFrame {
     args:string[];
     line:number;
     column:number;
-    context:string[];
+    context:null | string[];
 }
 
 export interface StackTrace {


### PR DESCRIPTION
I modified the type because the case where context is null is tested in the test case at [TraceKit's tracekit-parser-spec.js](https://github.com/csnover/TraceKit/blob/master/spec/tracekit-parser-spec.js#L29), and this situation also occurs in actual browser stacks.

Thank you.